### PR TITLE
Fix: Missing Tree config passing to template.

### DIFF
--- a/Form/UxMediaCollectionType.php
+++ b/Form/UxMediaCollectionType.php
@@ -29,6 +29,7 @@ class UxMediaCollectionType extends UxCollectionType implements DataTransformerI
 
         $entryOptionsNormalizer = function (Options $options, $value) {
             $value['conf'] = $options['conf'];
+            $value['tree'] = $options['tree'];
             $value['extra'] = $options['extra'];
             $value['block_name'] = 'entry';
             $value['label'] = false;

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Works like [Artgris/MediaBundle](https://github.com/artgris/MediaBundle) except 
 ```php
 $builder->add('Media', UxMediaType::class, [
     'conf' => 'default',
+    'tree' => true,
     'display_file_manager' => true,
     'display_clear_button' => true,
     'allow_crop' => true,

--- a/templates/_ux_media_widget.html.twig
+++ b/templates/_ux_media_widget.html.twig
@@ -1,5 +1,4 @@
 {% set collection = form.parent.vars.collection|default(false) %}
-{% apply spaceless %}
     {%- set attr = attr|default([])|merge({
         'class': attr.class|default('ux-media mb-2 border bg-white rounded'),
         'data-controller': attr['data-controller']|default('arkounay--ux-media--media'),
@@ -199,4 +198,4 @@
         </button>
     </div>
     </div>
-{% endapply %}
+


### PR DESCRIPTION
```
->add('images', UxMediaCollectionType::class, [
                'conf' => 'default',
                'tree' => true,
                'entry_options' => ['readonly' => false]
            ])
```