### PR TITLE
progressTarget.firstChild selects newline text

### DIFF
--- a/assets/dist/media_controller.js
+++ b/assets/dist/media_controller.js
@@ -208,7 +208,7 @@ function _pathUpdateEventListener2(data) {
 }
 function _toggleProgress2(show) {
   if (show) {
-    this.progressTarget.firstChild.style.width = '0%';
+    this.progressTarget.firstElementChild.style.width = '0%';
     this.progressTarget.classList.remove('d-none');
   } else {
     this.progressTarget.classList.add('d-none');
@@ -259,7 +259,7 @@ function _uploadFiles2(files) {
     };
     xhr.upload.onprogress = function (event) {
       var percent = event.loaded / event.total * 100;
-      _this4.progressTarget.firstChild.style.width = percent + '%';
+      _this4.progressTarget.firstElementChild.style.width = percent + '%';
     };
     xhr.send(data);
   }

--- a/assets/src/media_controller.js
+++ b/assets/src/media_controller.js
@@ -46,7 +46,7 @@ export default class extends Controller {
 
     #toggleProgress(show) {
         if (show) {
-            this.progressTarget.firstChild.style.width = '0%';
+            this.progressTarget.firstElementChild.style.width = '0%';
             this.progressTarget.classList.remove('d-none');
         } else {
             this.progressTarget.classList.add('d-none');
@@ -100,7 +100,7 @@ export default class extends Controller {
 
             xhr.upload.onprogress = (event) => {
                 const percent = event.loaded / event.total * 100;
-                this.progressTarget.firstChild.style.width = percent + '%';
+                this.progressTarget.firstElementChild.style.width = percent + '%';
             };
 
             xhr.send(data);


### PR DESCRIPTION
this.progressTarget.firstChild selects the newline text between the "progress" div and the "progressBar" child div.  This causes an error when uploading a file when the progress bar is supposed to be shown:

```
Error invoking action "input->arkounay--ux-media--media#upload"

TypeError: Cannot set properties of undefined (setting 'width')
    at t._toggleProgress2 (media_controller-0fcb36342303a3ef528b46a1e7e4c5b4.js:211:48)
    at t._uploadFiles2 (media_controller-0fcb36342303a3ef528b46a1e7e4c5b4.js:224:72)
    at t.upload (media_controller-0fcb36342303a3ef528b46a1e7e4c5b4.js:86:66)
    at f.invokeWithEvent (stimulus.index-b5b1d00e42695b8959b4a1e94e3bc92a.js:7:6516)
    at f.handleEvent (stimulus.index-b5b1d00e42695b8959b4a1e94e3bc92a.js:7:5848)
    at e.handleEvent (stimulus.index-b5b1d00e42695b8959b4a1e94e3bc92a.js:7:721)
```